### PR TITLE
loop unrolling

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -118,44 +118,36 @@ static void raise_strict(VALUE obj) {
              rb_class2name(rb_obj_class(obj)));
 }
 
-inline static size_t newline_friendly_size(const uint8_t *str, size_t len) {
+inline static size_t calculate_string_size(const uint8_t *str, size_t len, const char * table) {
     size_t size = 0;
     size_t i    = len;
 
-    for (; 0 < i; str++, i--) {
-        size += newline_friendly_chars[*str];
+    for (; 3 < i; i -= 4) {
+        size += table[*str++];
+        size += table[*str++];
+        size += table[*str++];
+        size += table[*str++];
+    }
+    for (; 0 < i; i--) {
+        size += table[*str++];
     }
     return size - len * (size_t)'0';
+}
+
+inline static size_t newline_friendly_size(const uint8_t *str, size_t len) {
+    return calculate_string_size(str, len, newline_friendly_chars);
 }
 
 inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += hibit_friendly_chars[*str];
-    }
-    return size - len * (size_t)'0';
+    return calculate_string_size(str, len, hibit_friendly_chars);
 }
 
 inline static size_t ascii_friendly_size(const uint8_t *str, size_t len) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += ascii_friendly_chars[*str];
-    }
-    return size - len * (size_t)'0';
+    return calculate_string_size(str, len, ascii_friendly_chars);
 }
 
 inline static size_t xss_friendly_size(const uint8_t *str, size_t len) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += xss_friendly_chars[*str];
-    }
-    return size - len * (size_t)'0';
+    return calculate_string_size(str, len, xss_friendly_chars);
 }
 
 inline static size_t hixss_friendly_size(const uint8_t *str, size_t len) {
@@ -188,12 +180,7 @@ inline static long rails_xss_friendly_size(const uint8_t *str, size_t len) {
 }
 
 inline static size_t rails_friendly_size(const uint8_t *str, size_t len) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += rails_friendly_chars[*str];
-    }
+    size_t size = calculate_string_size(str, len, rails_friendly_chars);
     return size - len * (size_t)'0';
 }
 


### PR DESCRIPTION
Unrolling simple processing loops seems to improve performance when compiled with GCC.

−               | before | after  | result
--               | --     | --     | --
Oj.dump (macOS)  | 1.016M | 1.048M | 1.031x
Oj.dump (Linux)  | 0.984M | 1.143M | 1.162x

### Environment
- macOS
  - macOS 12.1
  - Apple M1 Max
  - Apple clang version 13.0.0 (clang-1300.0.29.30)
  - Ruby 3.0.2
- Linux
  - Zorin OS 16
  - AMD Ryzen 7 5700G
  - gcc version 9.3.0
  - Ruby 3.0.2

### macOS
#### Before
```
Warming up --------------------------------------
             Oj.dump   101.770k i/100ms
Calculating -------------------------------------
             Oj.dump      1.016M (± 0.5%) i/s -     10.177M in  10.012877s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   104.842k i/100ms
Calculating -------------------------------------
             Oj.dump      1.048M (± 0.6%) i/s -     10.484M in  10.008101s
```

### Linux
#### Before
```
Warming up --------------------------------------
             Oj.dump    98.852k i/100ms
Calculating -------------------------------------
             Oj.dump    983.725k (± 1.9%) i/s -      9.885M in  10.052621s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   111.510k i/100ms
Calculating -------------------------------------
             Oj.dump      1.143M (± 1.4%) i/s -     11.486M in  10.050827s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 10

  data = Oj.load(json)
  x.report('Oj.dump') { Oj.dump(data, mode: :compat) }
end
```